### PR TITLE
Fix docker-compose API IP binding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     image: bakingbad/tzkt-api:latest
     depends_on:
       - db
+    environment:
+      - TZKT_API_KESTREL__ENDPOINTS__HTTP__URL=http://0.0.0.0:5000
     expose:
       - 5000
     ports:


### PR DESCRIPTION
The API has some issues binding to localhost in a docker container (the actual error is `ECONNRESET`). I don't fully understand the issue, this might not be the best place to address it -- but other people have raised the issue in Discord as well.

Relevant logs:
```
<4>Microsoft.AspNetCore.Server.Kestrel[0] Unable to bind to http://localhost:5000 on the IPv6 loopback interface: 'Cannot assign requested address'.
<6>Microsoft.Hosting.Lifetime[0] Now listening on: http://localhost:5000
```