### PR TITLE
Feat: add a tzkt user into Docker images

### DIFF
--- a/Tzkt.Api/Dockerfile
+++ b/Tzkt.Api/Dockerfile
@@ -5,7 +5,10 @@ RUN cd Tzkt.Api && dotnet publish -o output
 
 FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS=http://+:5000
+RUN groupadd --gid 1000 tzkt \
+    && useradd --gid tzkt --no-create-home --uid 1000 tzkt
 WORKDIR /app
 EXPOSE 5000
 COPY --from=build /app/Tzkt.Api/output ./
+USER tzkt
 ENTRYPOINT ["dotnet", "Tzkt.Api.dll"]

--- a/Tzkt.Sync/Dockerfile
+++ b/Tzkt.Sync/Dockerfile
@@ -4,6 +4,9 @@ COPY . .
 RUN cd Tzkt.Sync && dotnet publish -o output
 
 FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
+RUN groupadd --gid 1000 tzkt \
+    && useradd --gid tzkt --no-create-home --uid 1000 tzkt
 WORKDIR /app
 COPY --from=build /app/Tzkt.Sync/output ./
+USER tzkt
 ENTRYPOINT ["dotnet", "Tzkt.Sync.dll"]


### PR DESCRIPTION
Add a tzkt user in the Api and Sync docker images.
Avoid the container to run as root.

Signed-off-by: Pierre-Emmanuel Andre <pea@phenylethylamine.io>