### PR TITLE
Generate JSONSchema for all entrypoints

### DIFF
--- a/Tzkt.Api/Repositories/AccountRepository.Contracts.cs
+++ b/Tzkt.Api/Repositories/AccountRepository.Contracts.cs
@@ -933,7 +933,6 @@ namespace Tzkt.Api.Repositories
             {
                 StorageSchema = storage.GetJsonSchema(),
                 Entrypoints = param.Entrypoints
-                    .Where(x => param.IsEntrypointUseful(x.Key))
                     .Select(x => new EntrypointInterface
                     {
                         Name = x.Key,


### PR DESCRIPTION
Including default and intermediary ones.
Context: DipDup codegen cannot generate types if user specifies "default" as entrypoint name.