### PR TITLE
Expose endpoint to query smart rollup parameter json schema

### DIFF
--- a/Tzkt.Api/Controllers/SmartRollupsController.cs
+++ b/Tzkt.Api/Controllers/SmartRollupsController.cs
@@ -93,6 +93,27 @@ namespace Tzkt.Api.Controllers
         }
 
         /// <summary>
+        /// Get JSON Schema [2020-12] interface for the smart rollup
+        /// </summary>
+        /// <remarks>
+        /// Returns standard JSON Schema for smart rollup parameter.
+        /// </remarks>
+        /// <param name="address">Smart rollup address</param>
+        /// <returns></returns>
+        [HttpGet("{address}/interface")]
+        public async Task<ActionResult<ContractInterface>> GetInterface([Required][Address] string address)
+        {
+            var query = ResponseCacheService.BuildKey(Request.Path.Value);
+
+            if (ResponseCache.TryGet(query, out var cached))
+                return this.Bytes(cached);
+
+            var res = await SmartRollups.GetSmartRollupInterface(address);
+            cached = ResponseCache.Set(query, res);
+            return this.Bytes(cached);
+        }
+
+        /// <summary>
         /// Get smart rollup stakers
         /// </summary>
         /// <remarks>

--- a/Tzkt.Api/Repositories/SmartRollupsRepository.cs
+++ b/Tzkt.Api/Repositories/SmartRollupsRepository.cs
@@ -214,13 +214,13 @@ namespace Tzkt.Api.Repositories
 
             using var db = GetConnection();
 
-            var parameterType = await db.QueryFirstOrDefaultAsync($@"
+            var origination = await db.QueryFirstOrDefaultAsync($@"
                 SELECT      ""ParameterType""
                 FROM        ""SmartRollupOriginateOps""
                 WHERE       ""SmartRollupId"" = {rollup.Id}
                 LIMIT       1"
             );
-            if (parameterType is not byte[] bytes)
+            if (origination.ParameterType is not byte[] bytes)
                 return null;
 
             return Schema.Create(Micheline.FromBytes(bytes) as MichelinePrim).GetJsonSchema();

--- a/Tzkt.Api/Repositories/SmartRollupsRepository.cs
+++ b/Tzkt.Api/Repositories/SmartRollupsRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Data;
 using Dapper;
 using Netezos.Encoding;
+using Netezos.Contracts;
 using Tzkt.Api.Models;
 using Tzkt.Api.Services.Cache;
 
@@ -203,6 +204,26 @@ namespace Tzkt.Api.Repositories
                 LastActivityTime = Times[rollup.LastLevel],
                 Extras = rollup.Extras
             };
+        }
+
+        public async Task<RawJson> GetSmartRollupInterface(string address)
+        {
+            var rawAccount = await Accounts.GetAsync(address);
+            if (rawAccount is not RawSmartRollup rollup)
+                return null;
+
+            using var db = GetConnection();
+
+            var parameterType = await db.QueryFirstOrDefaultAsync($@"
+                SELECT      ""ParameterType""
+                FROM        ""SmartRollupOriginateOps""
+                WHERE       ""SmartRollupId"" = {rollup.Id}
+                LIMIT       1"
+            );
+            if (parameterType is not byte[] bytes)
+                return null;
+
+            return Schema.Create(Micheline.FromBytes(bytes) as MichelinePrim).GetJsonSchema();
         }
 
         public async Task<IEnumerable<SmartRollup>> GetSmartRollups(SrFilter filter, Pagination pagination)


### PR DESCRIPTION
In order to add support for smart rollups in DipDup framework we need JSON schemas for rollup parameters to generate typed models (similarly to smart contracts).

Example:
https://tzkt-nairobinet.dipdup.net/v1/smart_rollups/sr1UrPcVycLQ9zYv4jSMnBoqLqB6CLZKrHnW/interface