### PR TITLE
Use UNION instead of ANY for transactions query

### DIFF
--- a/Tzkt.Api/Repositories/OperationRepository.Transactions.cs
+++ b/Tzkt.Api/Repositories/OperationRepository.Transactions.cs
@@ -50,7 +50,7 @@ namespace Tzkt.Api.Repositories
             var sql = $@"
                 SELECT      o.*, b.""Hash""
                 FROM        ""TransactionOps"" as o
-                INNER JOIN  ""Blocks"" as b 
+                INNER JOIN  ""Blocks"" as b
                         ON  b.""Level"" = o.""Level""
                 WHERE       o.""OpHash"" = @hash::character(51)
                 ORDER BY    o.""Id""";
@@ -126,7 +126,7 @@ namespace Tzkt.Api.Repositories
             var sql = $@"
                 SELECT      o.*, b.""Hash""
                 FROM        ""TransactionOps"" as o
-                INNER JOIN  ""Blocks"" as b 
+                INNER JOIN  ""Blocks"" as b
                         ON  b.""Level"" = o.""Level""
                 WHERE       o.""OpHash"" = @hash::character(51) AND o.""Counter"" = @counter
                 ORDER BY    o.""Id""";
@@ -202,7 +202,7 @@ namespace Tzkt.Api.Repositories
             var sql = $@"
                 SELECT      o.*, b.""Hash""
                 FROM        ""TransactionOps"" as o
-                INNER JOIN  ""Blocks"" as b 
+                INNER JOIN  ""Blocks"" as b
                         ON  b.""Level"" = o.""Level""
                 WHERE       o.""OpHash"" = @hash::character(51) AND o.""Counter"" = @counter AND o.""Nonce"" = @nonce
                 LIMIT       1";
@@ -352,12 +352,15 @@ namespace Tzkt.Api.Repositories
             bool includeStorage = false,
             bool includeBigmaps = false)
         {
-            var sql = new SqlBuilder(@"
+            var transactionsQuery =
+                new SqlBuilder(@"SELECT * FROM ""TransactionOps""")
+                    .FilterWithUnion(anyof, x => x == "sender" ? "SenderId" : x == "target" ? "TargetId" : "InitiatorId");
+
+            var sql = new SqlBuilder($@"
                 SELECT      o.*, b.""Hash""
-                FROM        ""TransactionOps"" AS o
+                FROM        ({transactionsQuery.Query}) AS o
                 INNER JOIN  ""Blocks"" as b
                         ON  b.""Level"" = o.""Level""")
-                .Filter(anyof, x => x == "sender" ? "SenderId" : x == "target" ? "TargetId" : "InitiatorId")
                 .Filter("InitiatorId", initiator, x => "TargetId")
                 .Filter("SenderId", sender, x => "TargetId")
                 .Filter("TargetId", target, x => x == "sender" ? "SenderId" : "InitiatorId")


### PR DESCRIPTION
## The problem
The `TransactionsOps` table is huge and even though there are indices on each column, sometimes, with `anyof` param passed in for example, we get a *very* slow performance.

Example request is: https://api.tzkt.io/v1/operations/transactions?anyof.sender.target.initiator.in=tz1gM3DG4GTb49DDs9XPkz7YbfTQrQvgsvNg,tz1dBt9tmR97ZuSSU31TCyBcHG93rgxqzX5N,tz1aRoaRhSpRYvFdyvgWLL6TGyRoGF51wDjM&sort.id=desc&limit=100

Here's the SQL it'd generate (Ids are replaced):
```sql
SELECT
	o.*
FROM
	"TransactionOps" AS o
WHERE
	(
		"SenderId" IN (
			50001,50002,50003,50004,5
		)
		OR "TargetId" IN (
			50001,50002,50003,50004,5
		)
		OR "InitiatorId" IN (
			50001,50002,50003,50004,5
		)
	)
ORDER BY
	o."Id" DESC
LIMIT
	100;
```

That's the output of `EXPLAIN ANALYZE`:
```
                                                                                                         QUERY PLAN                                                                                                         
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1000.59..13227.99 rows=100 width=476) (actual time=352274.035..998864.422 rows=36 loops=1)
   ->  Gather Merge  (cost=1000.59..14230140.14 rows=116371 width=476) (actual time=352274.033..998864.409 rows=36 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Parallel Index Scan Backward using "PK_TransactionOps" on "TransactionOps" o  (cost=0.57..14215708.01 rows=48488 width=476) (actual time=139776.984..774402.487 rows=12 loops=3)
               Filter: (("SenderId" = ANY ('{50001,50002,50003,50004,5}'::integer[])) OR ("TargetId" = ANY ('{50001,50002,50003,50004,5}'::integer[])) OR ("InitiatorId" = ANY ('{50001,50002,50003,50004,5}'::integer[])))
               Rows Removed by Filter: 70214035
 Planning Time: 0.177 ms
 Execution Time: 998864.453 ms
```

the main parts are:  *Rows Removed by Filter: 70214035* and *Execution Time: 998864.453 ms*

as I said before, it's not always so bad. Once you have the data in cache the lookups become much much quicker. Also, if you have more workers per gather it'll also improve the performance. 

## Why it happens

The reason is that PG does a full index scan when it encounters ANY or IN operator with sorting on the `Id` (PK) field.
Sometimes though it works quite well (when you have the whole PK index in memory for example), but in general, it might lead to quite slow query time (not to mention that it'll consume as many PG worker processes as it can get).

It's a [known problem](https://dba.stackexchange.com/questions/293836/why-is-an-or-statement-slower-than-union) with SQL engines unfortunately

## ~~The solution~~ The crutch

The simplest way to fix the problem is to convert all these ANY operators into UNIONs of separate relations. Even though the SQL query itself becomes huge, it has quite predictable performance because all the subqueries successfully utilise corresponding indices.

Example query:
```sql
SELECT o.*,
	b."Hash"
FROM (
		SELECT *
		FROM "TransactionOps"
		WHERE "SenderId" = 1296630
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "SenderId" = 1296977
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "SenderId" = 3135948
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "SenderId" = 3223526
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "SenderId" = 4096916
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "SenderId" = 4096932
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "SenderId" = 4097761
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "TargetId" = 1296630
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "TargetId" = 1296977
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "TargetId" = 3135948
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "TargetId" = 3223526
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "TargetId" = 4096916
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "TargetId" = 4096932
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "TargetId" = 4097761
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "InitiatorId" = 1296630
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "InitiatorId" = 1296977
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "InitiatorId" = 3135948
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "InitiatorId" = 3223526
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "InitiatorId" = 4096916
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "InitiatorId" = 4096932
		
		UNION
		
		SELECT *
		FROM "TransactionOps"
		WHERE "InitiatorId" = 4097761
	) AS o
	INNER JOIN "Blocks" as b ON b."Level" = o."Level"
ORDER BY o."Id" DESC
LIMIT 100;

 ```


The `EXPLAIN ANALYZE` output:
```
                                                                                                                                                                                                                                                                                                                                                                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=938483.66..938483.91 rows=100 width=522) (actual time=1303.238..1303.266 rows=100 loops=1)
   ->  Sort  (cost=938483.66..938891.02 rows=162946 width=522) (actual time=801.292..801.316 rows=100 loops=1)
         Sort Key: "TransactionOps"."Id" DESC
         Sort Method: top-N heapsort  Memory: 106kB
         ->  Merge Join  (cost=663640.73..932255.98 rows=162946 width=522) (actual time=233.578..801.085 rows=360 loops=1)
               Merge Cond: (b."Level" = "TransactionOps"."Level")
               ->  Index Scan using "IX_Blocks_Level" on "Blocks" b  (cost=0.43..253201.94 rows=5024877 width=56) (actual time=0.035..628.398 rows=5019848 loops=1)
               ->  Materialize  (cost=663640.30..664455.03 rows=162946 width=470) (actual time=1.189..1.298 rows=360 loops=1)
                     ->  Sort  (cost=663640.30..664047.66 rows=162946 width=470) (actual time=1.187..1.242 rows=360 loops=1)
                           Sort Key: "TransactionOps"."Level"
                           Sort Method: quicksort  Memory: 171kB
                           ->  Unique  (cost=564177.43..578842.57 rows=162946 width=470) (actual time=1.060..1.170 rows=360 loops=1)
                                 ->  Sort  (cost=564177.43..564584.80 rows=162946 width=470) (actual time=1.059..1.080 rows=433 loops=1)
                                       Sort Key: "TransactionOps"."Id", "TransactionOps"."SenderCodeHash", "TransactionOps"."TargetId", "TransactionOps"."TargetCodeHash", "TransactionOps"."ResetDeactivation", "TransactionOps"."Amount", "TransactionOps"."Entrypoint", "TransactionOps"."RawParameters", "TransactionOps"."JsonParameters", "TransactionOps"."InternalOperations", "TransactionOps"."InternalDelegations", "TransactionOps"."InternalOriginations", "TransactionOps"."InternalTransactions", "TransactionOps"."EventsCount", "TransactionOps"."Level", "TransactionOps"."Timestamp", "TransactionOps"."OpHash", "TransactionOps"."SenderId", "TransactionOps"."Counter", "TransactionOps"."BakerFee", "TransactionOps"."StorageFee", "TransactionOps"."Allo
cationFee", "TransactionOps"."GasLimit", "TransactionOps"."GasUsed", "TransactionOps"."StorageLimit", "TransactionOps"."StorageUsed", "TransactionOps"."Status", "TransactionOps"."Errors", "TransactionOps"."InitiatorId", "TransactionOps"."Nonce", "TransactionOps"."StorageId", "TransactionOps"."BigMapUpdates", "TransactionOps"."TokenTransfers", "TransactionOps"."SubIds", "TransactionOps"."TicketTransfers"
                                       Sort Method: quicksort  Memory: 194kB
                                       ->  Append  (cost=0.57..481009.17 rows=162946 width=470) (actual time=0.023..0.926 rows=433 loops=1)
                                             ->  Index Scan using "IX_TransactionOps_SenderId" on "TransactionOps"  (cost=0.57..32779.74 rows=10519 width=476) (actual time=0.022..0.299 rows=96 loops=1)
                                                   Index Cond: ("SenderId" = 1296630)
                                             ->  Index Scan using "IX_TransactionOps_SenderId" on "TransactionOps" "TransactionOps_1"  (cost=0.57..32779.74 rows=10519 width=476) (actual time=0.009..0.085 rows=31 loops=1)
                                                   Index Cond: ("SenderId" = 1296977)
                                             ->  Index Scan using "IX_TransactionOps_SenderId" on "TransactionOps" "TransactionOps_2"  (cost=0.57..32779.74 rows=10519 width=476) (actual time=0.012..0.089 rows=30 loops=1)
                                                   Index Cond: ("SenderId" = 3135948)
                                             ->  Index Scan using "IX_TransactionOps_SenderId" on "TransactionOps" "TransactionOps_3"  (cost=0.57..32779.74 rows=10519 width=476) (actual time=0.010..0.133 rows=61 loops=1)
                                                   Index Cond: ("SenderId" = 3223526)
                                             ->  Index Scan using "IX_TransactionOps_SenderId" on "TransactionOps" "TransactionOps_4"  (cost=0.57..32779.74 rows=10519 width=476) (actual time=0.006..0.007 rows=0 loops=1)
                                                   Index Cond: ("SenderId" = 4096916)
                                             ->  Index Scan using "IX_TransactionOps_SenderId" on "TransactionOps" "TransactionOps_5"  (cost=0.57..32779.74 rows=10519 width=476) (actual time=0.002..0.002 rows=1 loops=1)
                                                   Index Cond: ("SenderId" = 4096932)
                                             ->  Index Scan using "IX_TransactionOps_SenderId" on "TransactionOps" "TransactionOps_6"  (cost=0.57..32779.74 rows=10519 width=476) (actual time=0.004..0.004 rows=1 loops=1)
                                                   Index Cond: ("SenderId" = 4097761)
                                             ->  Index Scan using "IX_TransactionOps_TargetId" on "TransactionOps" "TransactionOps_7"  (cost=0.57..16875.82 rows=6160 width=476) (actual time=0.014..0.030 rows=32 loops=1)
                                                   Index Cond: ("TargetId" = 1296630)
                                             ->  Index Scan using "IX_TransactionOps_TargetId" on "TransactionOps" "TransactionOps_8"  (cost=0.57..16875.82 rows=6160 width=476) (actual time=0.004..0.018 rows=22 loops=1)
                                                   Index Cond: ("TargetId" = 1296977)
                                             ->  Index Scan using "IX_TransactionOps_TargetId" on "TransactionOps" "TransactionOps_9"  (cost=0.57..16875.82 rows=6160 width=476) (actual time=0.010..0.010 rows=3 loops=1)
                                                   Index Cond: ("TargetId" = 3135948)
                                             ->  Index Scan using "IX_TransactionOps_TargetId" on "TransactionOps" "TransactionOps_10"  (cost=0.57..16875.82 rows=6160 width=476) (actual time=0.008..0.123 rows=46 loops=1)
                                                   Index Cond: ("TargetId" = 3223526)
                                             ->  Index Scan using "IX_TransactionOps_TargetId" on "TransactionOps" "TransactionOps_11"  (cost=0.57..16875.82 rows=6160 width=476) (actual time=0.007..0.007 rows=0 loops=1)
                                                   Index Cond: ("TargetId" = 4096916)
                                             ->  Index Scan using "IX_TransactionOps_TargetId" on "TransactionOps" "TransactionOps_12"  (cost=0.57..16875.82 rows=6160 width=476) (actual time=0.001..0.005 rows=17 loops=1)
                                                   Index Cond: ("TargetId" = 4096932)
                                             ->  Index Scan using "IX_TransactionOps_TargetId" on "TransactionOps" "TransactionOps_13"  (cost=0.57..16875.82 rows=6160 width=476) (actual time=0.004..0.005 rows=4 loops=1)
                                                   Index Cond: ("TargetId" = 4097761)
                                             ->  Index Scan using "IX_TransactionOps_InitiatorId" on "TransactionOps" "TransactionOps_14"  (cost=0.57..18710.87 rows=6599 width=476) (actual time=0.014..0.022 rows=26 loops=1)
                                                   Index Cond: ("InitiatorId" = 1296630)
                                             ->  Index Scan using "IX_TransactionOps_InitiatorId" on "TransactionOps" "TransactionOps_15"  (cost=0.57..18710.87 rows=6599 width=476) (actual time=0.006..0.020 rows=18 loops=1)
                                                   Index Cond: ("InitiatorId" = 1296977)
                                             ->  Index Scan using "IX_TransactionOps_InitiatorId" on "TransactionOps" "TransactionOps_16"  (cost=0.57..18710.87 rows=6599 width=476) (actual time=0.008..0.009 rows=8 loops=1)
                                                   Index Cond: ("InitiatorId" = 3135948)
                                             ->  Index Scan using "IX_TransactionOps_InitiatorId" on "TransactionOps" "TransactionOps_17"  (cost=0.57..18710.87 rows=6599 width=476) (actual time=0.006..0.011 rows=37 loops=1)
                                                   Index Cond: ("InitiatorId" = 3223526)
                                             ->  Index Scan using "IX_TransactionOps_InitiatorId" on "TransactionOps" "TransactionOps_18"  (cost=0.57..18710.87 rows=6599 width=476) (actual time=0.006..0.006 rows=0 loops=1)
                                                   Index Cond: ("InitiatorId" = 4096916)
                                             ->  Index Scan using "IX_TransactionOps_InitiatorId" on "TransactionOps" "TransactionOps_19"  (cost=0.57..18710.87 rows=6599 width=476) (actual time=0.003..0.003 rows=0 loops=1)
                                                   Index Cond: ("InitiatorId" = 4096932)
                                             ->  Index Scan using "IX_TransactionOps_InitiatorId" on "TransactionOps" "TransactionOps_20"  (cost=0.57..18710.87 rows=6599 width=476) (actual time=0.003..0.003 rows=0 loops=1)
                                                   Index Cond: ("InitiatorId" = 4097761)
 Planning Time: 0.862 ms
 JIT:
   Functions: 51
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 2.822 ms, Inlining 5.701 ms, Optimization 314.287 ms, Emission 181.976 ms, Total 504.786 ms
 Execution Time: 1306.288 ms
(64 rows)
```

so, the execution time drops significantly.
Yes, that's true that once the original query is cached in some way it will be faster, but the first operation will always be slow. This solution has predictable and fast enough performance.

## Limitations
1. The new method isn't composable, so we need to use two SqlBuilder objects
2. The solution covers only the case for the `anyof` param, but doesn't address the same issue with, let's say /transactions?sender.in=... queries. it's a bit different and definitely more complicated because we need to keep in mind the `AND` nature of the sender, target, initator params